### PR TITLE
0.9.0: address review findings (range validation, I/O-safety refactor, Windows leak fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ version line: the `[memmapix] 0.9.0` entry below is unrelated to `memmap2`'s
 - Validate `offset + len` in the safe `flush_range`, `flush_async_range`, and
   `advise_range` methods of `Mmap`, `MmapMut`, and `MmapRaw`. Out-of-bounds or
   overflowing inputs now return `ErrorKind::InvalidInput` instead of reaching
-  unchecked pointer arithmetic in the Unix/Windows backends.
+  unchecked pointer arithmetic in the Unix/Windows backends. Zero-length
+  ranges short-circuit before the backend call, both to avoid materializing
+  a one-past-the-end pointer and because `FlushViewOfFile(ptr, 0)` on
+  Windows is documented to flush "from base to end of the mapping" rather
+  than being a no-op.
 - Close a soundness hole in `MmapOptions::map_raw`/`map_raw_read_only` and
   `MmapRaw::map_raw`: previously a safe caller could pass a bare
   `RawFd`/`RawHandle` that would reach `File::from_raw_fd` (claims ownership)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+`memmapix` is a fork of [`memmap2`](https://github.com/RazrFalcon/memmap2-rs)
+that swaps `libc` for `rustix`. The entries below marked `[memmapix]` track
+changes made in this fork; the remaining entries document the inherited
+`memmap2` history up to the fork point. Note that `memmapix` uses its own
+version line: the `[memmapix] 0.9.0` entry below is unrelated to `memmap2`'s
+`0.9.0` further down.
+
+## [0.9.0] - 2026-04-23
+### [memmapix] Fixed
+- Validate `offset + len` in the safe `flush_range`, `flush_async_range`, and
+  `advise_range` methods of `Mmap`, `MmapMut`, and `MmapRaw`. Out-of-bounds or
+  overflowing inputs now return `ErrorKind::InvalidInput` instead of reaching
+  unchecked pointer arithmetic in the Unix/Windows backends.
+- Close a soundness hole in `MmapOptions::map_raw`/`map_raw_read_only` and
+  `MmapRaw::map_raw`: previously a safe caller could pass a bare
+  `RawFd`/`RawHandle` that would reach `File::from_raw_fd` (claims ownership)
+  or `BorrowedFd::borrow_raw` (requires a valid open descriptor), violating
+  an unsafe precondition from safe code. `MmapAsRawDesc` is now gated on the
+  I/O-safety traits (`AsFd` on Unix, `AsHandle` on Windows), which give a
+  compiler-checked "descriptor is open" invariant on the borrow handed to
+  the OS backend. Safe callers passing `&File` / `File` / `BorrowedFd` work
+  unchanged; users holding a bare raw integer now construct a
+  `BorrowedFd::borrow_raw` / `BorrowedHandle::borrow_raw` themselves in an
+  `unsafe` block, which is where the validity precondition belongs. This
+  also drops the `FromRawFd`/`FromRawHandle` ownership claim previously made
+  by `file_len`.
+- Call `UnmapViewOfFile` before returning when `VirtualProtect` fails in the
+  Windows anonymous-map path, fixing a view leak.
+
+### [memmapix] Changed (breaking — soundness fix)
+- `impl MmapAsRawDesc for RawFd` / `impl MmapAsRawDesc for RawHandle` are
+  removed. Use `AsFd` / `AsHandle` types (e.g. `&File`, `BorrowedFd`,
+  `BorrowedHandle`) with the existing `map_*` methods. If you only have a
+  raw integer, wrap it with `unsafe { BorrowedFd::borrow_raw(fd) }` (or the
+  Windows equivalent) before calling in.
+- The `AsRawFd`/`AsRawHandle` bound on the blanket `MmapAsRawDesc` impl is
+  replaced with `AsFd`/`AsHandle`. Standard-library types such as `File`
+  implement both, so callers passing `&File` are unaffected.
+- Internal: `os::file_len` and `os::MmapInner::new` / `map*` now take
+  `BorrowedFd<'_>` / `BorrowedHandle<'_>` instead of the raw types. No
+  `BorrowedFd::borrow_raw` / `BorrowedHandle::borrow_raw` call remains on
+  any code path reachable from a safe API.
+
 ## [0.9.10] - 2026-02-15
 ### Fixed
 - Fix compilation on AIX targets.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memmapix"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Yevhenii Reizner <razrfalcon@gmail.com>",
@@ -19,7 +19,7 @@ rust-version = "1.63.0"
 stable_deref_trait = { version = "1.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "1", features = ["mm", "param"] }
+rustix = { version = "1", features = ["mm", "param", "fs"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 linux-raw-sys = { version = "0.12", default-features = false, features = ["general", "no_std"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,10 +126,25 @@ impl<T: AsHandle + ?Sized> MmapAsRawDesc for T {
   }
 }
 
-/// Ensures `offset + len` fits inside `map_len` without overflow. Safe
-/// range-scoped APIs call this before delegating to the OS backend, which
-/// would otherwise reach unchecked pointer arithmetic on out-of-bounds input.
-fn check_range(offset: usize, len: usize, map_len: usize) -> Result<()> {
+/// Validates a range-scoped API's `offset`/`len` and reports whether the
+/// caller should invoke its OS backend.
+///
+/// Returns `Ok(true)` when the backend should be called, `Ok(false)` when
+/// the range is a valid no-op (`len == 0`), and `Err(InvalidInput)` when
+/// `offset + len` overflows or exceeds `map_len`.
+///
+/// The zero-length short-circuit prevents two hazards:
+///
+/// 1. When `offset == map_len && len == 0`, dispatching to the backend would
+///    materialize a one-past-the-end pointer via `ptr.offset(map_len)` /
+///    `ptr.add(map_len)`. Computing such a pointer is permitted by Rust,
+///    but handing it to the OS backend is at best noise and at worst
+///    ill-defined per the platform's API contract.
+/// 2. On Windows `FlushViewOfFile(ptr, 0)` is documented to flush "from
+///    the base address to the end of the mapping" — it is *not* a no-op.
+///    Calling safe `flush_range(o, 0)` must not silently become a
+///    full-range flush.
+fn check_range(offset: usize, len: usize, map_len: usize) -> Result<bool> {
   let end = offset
     .checked_add(len)
     .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "offset + len overflows usize"))?;
@@ -139,7 +154,7 @@ fn check_range(offset: usize, len: usize, map_len: usize) -> Result<()> {
       "offset + len exceeds the memory map's length",
     ));
   }
-  Ok(())
+  Ok(len != 0)
 }
 
 /// A memory map builder, providing advanced options and flags for specifying memory map behavior.
@@ -858,7 +873,9 @@ impl Mmap {
   /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
   #[cfg(unix)]
   pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.advise(advice.to_raw(), offset, len)
   }
 
@@ -1064,7 +1081,9 @@ impl MmapRaw {
   /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
   /// exceeds the memory map's length.
   pub fn flush_range(&self, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.flush(offset, len)
   }
 
@@ -1083,7 +1102,9 @@ impl MmapRaw {
   /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
   /// exceeds the memory map's length.
   pub fn flush_async_range(&self, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.flush_async(offset, len)
   }
 
@@ -1121,7 +1142,9 @@ impl MmapRaw {
   /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
   #[cfg(unix)]
   pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.advise(advice.to_raw(), offset, len)
   }
 
@@ -1353,7 +1376,9 @@ impl MmapMut {
   /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
   /// exceeds the memory map's length.
   pub fn flush_range(&self, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.flush(offset, len)
   }
 
@@ -1372,7 +1397,9 @@ impl MmapMut {
   /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
   /// exceeds the memory map's length.
   pub fn flush_async_range(&self, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.flush_async(offset, len)
   }
 
@@ -1460,7 +1487,9 @@ impl MmapMut {
   /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
   #[cfg(unix)]
   pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
-    check_range(offset, len, self.inner.len())?;
+    if !check_range(offset, len, self.inner.len())? {
+      return Ok(());
+    }
     self.inner.advise(advice.to_raw(), offset, len)
   }
 
@@ -1825,9 +1854,21 @@ mod test {
     let err = mmap.flush_async_range(0, 129).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 
-    // Exact-fit boundary is accepted.
+    // offset just past map_len with a positive len is rejected.
+    let err = mmap.flush_range(129, 0).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    // Exact-fit boundary is accepted as a full-range flush.
     mmap.flush_range(0, 128).unwrap();
+
+    // Zero-length ranges are no-ops and MUST NOT reach the backend — on
+    // Windows `FlushViewOfFile(ptr, 0)` is documented to flush from the
+    // base to the end of the mapping, and `ptr.add(map_len)` is one past
+    // the mapped view even if the `usize` arithmetic is in range.
     mmap.flush_range(128, 0).unwrap();
+    mmap.flush_range(64, 0).unwrap();
+    mmap.flush_range(0, 0).unwrap();
+    mmap.flush_async_range(128, 0).unwrap();
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1854,7 +1854,7 @@ mod test {
     let err = mmap.flush_async_range(0, 129).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 
-    // offset just past map_len with a positive len is rejected.
+    // An offset just past map_len is rejected even when len == 0.
     let err = mmap.flush_range(129, 0).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,9 @@ pub use crate::advice::{Advice, UncheckedAdvice};
 #[cfg(not(any(unix, windows)))]
 use std::fs::File;
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 #[cfg(windows)]
-use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::os::windows::io::{AsHandle, BorrowedHandle};
 use std::{
   fmt,
   io::{Error, ErrorKind, Result},
@@ -83,17 +83,26 @@ use std::{
 pub struct MmapRawDescriptor<'a>(&'a File);
 
 #[cfg(unix)]
-pub struct MmapRawDescriptor(RawFd);
+pub struct MmapRawDescriptor<'a>(BorrowedFd<'a>);
 
 #[cfg(windows)]
-pub struct MmapRawDescriptor(RawHandle);
+pub struct MmapRawDescriptor<'a>(BorrowedHandle<'a>);
 
+/// Types that can provide a borrowed file descriptor/handle to a memory map
+/// constructor.
+///
+/// The trait is implemented by anything that implements the I/O-safety
+/// traits [`AsFd`] (Unix) or [`AsHandle`] (Windows), which guarantees at the
+/// type-system level that the descriptor is open for the lifetime of the
+/// returned borrow. Bare `RawFd`/`RawHandle` integers intentionally do
+/// **not** implement this trait: safely obtaining a `BorrowedFd` /
+/// `BorrowedHandle` from a raw integer requires [`BorrowedFd::borrow_raw`] /
+/// [`BorrowedHandle::borrow_raw`], which are `unsafe fn`s whose validity
+/// precondition must be upheld by the caller. Users holding a bare raw
+/// descriptor should construct the borrow themselves in an `unsafe` block
+/// before calling into this crate.
 pub trait MmapAsRawDesc {
-  #[cfg(not(any(unix, windows)))]
   fn as_raw_desc(&self) -> MmapRawDescriptor<'_>;
-
-  #[cfg(any(unix, windows))]
-  fn as_raw_desc(&self) -> MmapRawDescriptor;
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -104,37 +113,33 @@ impl MmapAsRawDesc for &File {
 }
 
 #[cfg(unix)]
-impl MmapAsRawDesc for RawFd {
-  fn as_raw_desc(&self) -> MmapRawDescriptor {
-    MmapRawDescriptor(*self)
-  }
-}
-
-#[cfg(unix)]
-impl<T> MmapAsRawDesc for &T
-where
-  T: AsRawFd,
-{
-  fn as_raw_desc(&self) -> MmapRawDescriptor {
-    MmapRawDescriptor(self.as_raw_fd())
+impl<T: AsFd + ?Sized> MmapAsRawDesc for T {
+  fn as_raw_desc(&self) -> MmapRawDescriptor<'_> {
+    MmapRawDescriptor(self.as_fd())
   }
 }
 
 #[cfg(windows)]
-impl MmapAsRawDesc for RawHandle {
-  fn as_raw_desc(&self) -> MmapRawDescriptor {
-    MmapRawDescriptor(*self)
+impl<T: AsHandle + ?Sized> MmapAsRawDesc for T {
+  fn as_raw_desc(&self) -> MmapRawDescriptor<'_> {
+    MmapRawDescriptor(self.as_handle())
   }
 }
 
-#[cfg(windows)]
-impl<T> MmapAsRawDesc for &T
-where
-  T: AsRawHandle,
-{
-  fn as_raw_desc(&self) -> MmapRawDescriptor {
-    MmapRawDescriptor(self.as_raw_handle())
+/// Ensures `offset + len` fits inside `map_len` without overflow. Safe
+/// range-scoped APIs call this before delegating to the OS backend, which
+/// would otherwise reach unchecked pointer arithmetic on out-of-bounds input.
+fn check_range(offset: usize, len: usize, map_len: usize) -> Result<()> {
+  let end = offset
+    .checked_add(len)
+    .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "offset + len overflows usize"))?;
+  if end > map_len {
+    return Err(Error::new(
+      ErrorKind::InvalidInput,
+      "offset + len exceeds the memory map's length",
+    ));
   }
+  Ok(())
 }
 
 /// A memory map builder, providing advanced options and flags for specifying memory map behavior.
@@ -639,6 +644,13 @@ impl MmapOptions {
 
   /// Creates a raw memory map.
   ///
+  /// Because [`MmapAsRawDesc`] is gated on [`AsFd`]/[`AsHandle`], the
+  /// descriptor passed in carries a compiler-checked validity guarantee
+  /// for the lifetime of the call — so this entry point is safe. Users
+  /// holding a bare `RawFd`/`RawHandle` integer must first wrap it in a
+  /// [`BorrowedFd::borrow_raw`]/[`BorrowedHandle::borrow_raw`] themselves
+  /// (both `unsafe`) and pass that in.
+  ///
   /// # Errors
   ///
   /// This method returns an error when the underlying system call fails, which can happen for a
@@ -662,6 +674,9 @@ impl MmapOptions {
   ///
   /// This is primarily useful to avoid intermediate `Mmap` instances when
   /// read-only access to files modified elsewhere are required.
+  ///
+  /// See [`MmapOptions::map_raw`] for the rationale of why this entry
+  /// point is safe despite handing out raw pointers.
   ///
   /// # Errors
   ///
@@ -835,9 +850,15 @@ impl Mmap {
   ///
   /// The offset and length must be in the bounds of the memory map.
   ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
+  ///
   /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
   #[cfg(unix)]
   pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.advise(advice.to_raw(), offset, len)
   }
 
@@ -1037,7 +1058,13 @@ impl MmapRaw {
   /// last modification timestamp) may not be updated. It is not guaranteed the only the changes
   /// in the specified range are flushed; other outstanding changes to the memory map may be
   /// flushed as well.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
   pub fn flush_range(&self, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.flush(offset, len)
   }
 
@@ -1050,7 +1077,13 @@ impl MmapRaw {
   /// modification timestamp) may not be updated. It is not guaranteed that the only changes
   /// flushed are those in the specified range; other outstanding changes to the memory map may
   /// be flushed as well.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
   pub fn flush_async_range(&self, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.flush_async(offset, len)
   }
 
@@ -1080,9 +1113,15 @@ impl MmapRaw {
   ///
   /// Only supported on Unix.
   ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
+  ///
   /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
   #[cfg(unix)]
   pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.advise(advice.to_raw(), offset, len)
   }
 
@@ -1308,7 +1347,13 @@ impl MmapMut {
   /// last modification timestamp) may not be updated. It is not guaranteed the only the changes
   /// in the specified range are flushed; other outstanding changes to the memory map may be
   /// flushed as well.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
   pub fn flush_range(&self, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.flush(offset, len)
   }
 
@@ -1321,7 +1366,13 @@ impl MmapMut {
   /// modification timestamp) may not be updated. It is not guaranteed that the only changes
   /// flushed are those in the specified range; other outstanding changes to the memory map may
   /// be flushed as well.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
   pub fn flush_async_range(&self, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.flush_async(offset, len)
   }
 
@@ -1401,9 +1452,15 @@ impl MmapMut {
   ///
   /// The offset and length must be in the bounds of the memory map.
   ///
+  /// # Errors
+  ///
+  /// Returns [`ErrorKind::InvalidInput`] if `offset + len` overflows or
+  /// exceeds the memory map's length.
+  ///
   /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
   #[cfg(unix)]
   pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
+    check_range(offset, len, self.inner.len())?;
     self.inner.advise(advice.to_raw(), offset, len)
   }
 
@@ -1556,7 +1613,7 @@ mod test {
   #[cfg(unix)]
   use crate::advice::{Advice, UncheckedAdvice};
   #[cfg(unix)]
-  use std::os::unix::io::AsRawFd;
+  use std::os::unix::io::{AsRawFd, BorrowedFd};
   #[cfg(windows)]
   use std::os::windows::fs::OpenOptionsExt;
   use std::{
@@ -1620,7 +1677,13 @@ mod test {
 
     file.set_len(expected_len as u64).unwrap();
 
-    let mut mmap = unsafe { MmapMut::map_mut(file.as_raw_fd()).unwrap() };
+    // Exercise the raw-fd path by wrapping a bare RawFd in a BorrowedFd.
+    // Constructing the borrow is `unsafe` (caller asserts the fd is open);
+    // the map call itself is safe only in contract: it remains `unsafe fn`
+    // because of the file-modification UB caveat shared by all file-backed
+    // `map_*` variants.
+    let raw_fd = file.as_raw_fd();
+    let mut mmap = unsafe { MmapMut::map_mut(BorrowedFd::borrow_raw(raw_fd)).unwrap() };
     let len = mmap.len();
     assert_eq!(expected_len, len);
 
@@ -1744,6 +1807,55 @@ mod test {
     (&mut mmap[..]).write_all(write).unwrap();
     mmap.flush_async_range(0, write.len()).unwrap();
     mmap.flush_range(0, write.len()).unwrap();
+  }
+
+  #[test]
+  fn flush_range_rejects_out_of_bounds() {
+    let mmap = MmapMut::map_anon(128).unwrap();
+
+    let err = mmap.flush_range(0, 129).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    let err = mmap.flush_range(64, 65).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    let err = mmap.flush_range(usize::MAX, 1).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    let err = mmap.flush_async_range(0, 129).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    // Exact-fit boundary is accepted.
+    mmap.flush_range(0, 128).unwrap();
+    mmap.flush_range(128, 0).unwrap();
+  }
+
+  #[test]
+  fn raw_flush_range_rejects_out_of_bounds() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join("mmap_raw_range");
+    let file = OpenOptions::new()
+      .read(true)
+      .write(true)
+      .create(true)
+      .truncate(true)
+      .open(path)
+      .unwrap();
+    file.set_len(64).unwrap();
+
+    let mmap = MmapRaw::map_raw(&file).unwrap();
+    let err = mmap.flush_range(0, 65).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    let err = mmap.flush_async_range(usize::MAX, 1).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn advise_range_rejects_out_of_bounds() {
+    let mmap = MmapMut::map_anon(128).unwrap();
+    let err = mmap.advise_range(Advice::Normal, 0, 129).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
   }
 
   #[test]
@@ -2046,7 +2158,7 @@ mod test {
     File::create(&path).unwrap().write_all(b"abc123").unwrap();
 
     let mmap = MmapOptions::new()
-      .map_raw_read_only(&File::open(&path).unwrap())
+      .map_raw_read_only(File::open(&path).unwrap())
       .unwrap();
 
     assert_eq!(mmap.len(), 6);
@@ -2450,7 +2562,7 @@ mod test {
 
     // Drive the read-only entry point too so its body is counted.
     let ro = MmapOptions::new()
-      .map_raw_read_only(&File::open(&path).unwrap())
+      .map_raw_read_only(File::open(&path).unwrap())
       .unwrap();
     assert_eq!(ro.len(), 256);
   }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,16 +1,11 @@
 use std::{
-  fs::File,
   io,
-  mem::ManuallyDrop,
-  os::unix::io::{FromRawFd, RawFd},
+  os::unix::io::BorrowedFd,
   ptr,
   sync::atomic::{AtomicUsize, Ordering},
 };
 
-use rustix::{
-  fd::BorrowedFd,
-  mm::{MapFlags, MprotectFlags, MsyncFlags, ProtFlags},
-};
+use rustix::mm::{MapFlags, MprotectFlags, MsyncFlags, ProtFlags};
 
 #[cfg(any(
   all(target_os = "linux", not(target_arch = "mips")),
@@ -77,7 +72,7 @@ impl MmapInner {
     len: usize,
     prot: ProtFlags,
     flags: MapFlags,
-    file: RawFd,
+    file: BorrowedFd<'_>,
     offset: u64,
   ) -> io::Result<MmapInner> {
     let alignment = offset % page_size() as u64;
@@ -86,8 +81,7 @@ impl MmapInner {
     let (map_len, map_offset) = Self::adjust_mmap_params(len, alignment as usize)?;
 
     unsafe {
-      let fd = BorrowedFd::borrow_raw(file);
-      match rustix::mm::mmap(ptr::null_mut(), map_len, prot, flags, fd, aligned_offset) {
+      match rustix::mm::mmap(ptr::null_mut(), map_len, prot, flags, file, aligned_offset) {
         Ok(ptr) => Ok(Self::from_raw_parts(ptr, len, map_offset)),
         Err(e) => Err(io::Error::from_raw_os_error(e.raw_os_error())),
       }
@@ -217,7 +211,7 @@ impl MmapInner {
 
   pub fn map(
     len: usize,
-    file: RawFd,
+    file: BorrowedFd<'_>,
     offset: u64,
     populate: bool,
     no_reserve: bool,
@@ -243,7 +237,7 @@ impl MmapInner {
 
   pub fn map_exec(
     len: usize,
-    file: RawFd,
+    file: BorrowedFd<'_>,
     offset: u64,
     populate: bool,
     no_reserve: bool,
@@ -269,7 +263,7 @@ impl MmapInner {
 
   pub fn map_mut(
     len: usize,
-    file: RawFd,
+    file: BorrowedFd<'_>,
     offset: u64,
     populate: bool,
     no_reserve: bool,
@@ -295,7 +289,7 @@ impl MmapInner {
 
   pub fn map_copy(
     len: usize,
-    file: RawFd,
+    file: BorrowedFd<'_>,
     offset: u64,
     populate: bool,
     no_reserve: bool,
@@ -321,7 +315,7 @@ impl MmapInner {
 
   pub fn map_copy_read_only(
     len: usize,
-    file: RawFd,
+    file: BorrowedFd<'_>,
     offset: u64,
     populate: bool,
     no_reserve: bool,
@@ -564,11 +558,16 @@ fn page_size() -> usize {
   }
 }
 
-pub fn file_len(file: RawFd) -> io::Result<u64> {
-  // SAFETY: We must not close the passed-in fd by dropping the File we create,
-  // we ensure this by immediately wrapping it in a ManuallyDrop.
-  unsafe {
-    let file = ManuallyDrop::new(File::from_raw_fd(file));
-    Ok(file.metadata()?.len())
-  }
+pub fn file_len(file: BorrowedFd<'_>) -> io::Result<u64> {
+  // `rustix::fs::fstat` dispatches to `fstat64` on Linux/emscripten/l4re,
+  // preserving 64-bit offsets on 32-bit targets. The caller's `BorrowedFd`
+  // carries a compiler-checked guarantee that the descriptor is open for
+  // the duration of the borrow — which is exactly the invariant `fstat`
+  // needs — so no `unsafe` construction is required at this layer. The
+  // descriptor validity precondition lives at the boundary where the
+  // `BorrowedFd` was first obtained (e.g. `AsFd::as_fd` on a `File`, which
+  // is safe; or `BorrowedFd::borrow_raw` in caller code, which is unsafe).
+  rustix::fs::fstat(file)
+    .map(|stat| stat.st_size as u64)
+    .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,12 +2,10 @@
 #![allow(non_snake_case)]
 
 use std::{
-  fs::File,
   io, mem,
-  mem::ManuallyDrop,
   os::{
     raw::c_void,
-    windows::io::{FromRawHandle, RawHandle},
+    windows::io::{AsRawHandle, BorrowedHandle, RawHandle},
   },
   ptr,
 };
@@ -135,6 +133,8 @@ extern "system" {
     lpflOldProtect: PDWORD,
   ) -> BOOL;
 
+  fn GetFileSizeEx(hFile: HANDLE, lpFileSize: *mut i64) -> BOOL;
+
   fn GetSystemInfo(lpSystemInfo: LPSYSTEM_INFO);
 }
 
@@ -229,11 +229,12 @@ impl MmapInner {
 
   pub fn map(
     len: usize,
-    handle: RawHandle,
+    handle: BorrowedHandle<'_>,
     offset: u64,
     _populate: bool,
     _no_reserve: bool,
   ) -> io::Result<MmapInner> {
+    let handle = handle.as_raw_handle();
     let write = protection_supported(handle, PAGE_READWRITE);
     let exec = protection_supported(handle, PAGE_EXECUTE_READ);
     let mut access = FILE_MAP_READ;
@@ -262,11 +263,12 @@ impl MmapInner {
 
   pub fn map_exec(
     len: usize,
-    handle: RawHandle,
+    handle: BorrowedHandle<'_>,
     offset: u64,
     _populate: bool,
     _no_reserve: bool,
   ) -> io::Result<MmapInner> {
+    let handle = handle.as_raw_handle();
     let write = protection_supported(handle, PAGE_READWRITE);
     let mut access = FILE_MAP_READ | FILE_MAP_EXECUTE;
     let protection = if write {
@@ -285,11 +287,12 @@ impl MmapInner {
 
   pub fn map_mut(
     len: usize,
-    handle: RawHandle,
+    handle: BorrowedHandle<'_>,
     offset: u64,
     _populate: bool,
     _no_reserve: bool,
   ) -> io::Result<MmapInner> {
+    let handle = handle.as_raw_handle();
     let exec = protection_supported(handle, PAGE_EXECUTE_READ);
     let mut access = FILE_MAP_READ | FILE_MAP_WRITE;
     let protection = if exec {
@@ -308,11 +311,12 @@ impl MmapInner {
 
   pub fn map_copy(
     len: usize,
-    handle: RawHandle,
+    handle: BorrowedHandle<'_>,
     offset: u64,
     _populate: bool,
     _no_reserve: bool,
   ) -> io::Result<MmapInner> {
+    let handle = handle.as_raw_handle();
     let exec = protection_supported(handle, PAGE_EXECUTE_READWRITE);
     let mut access = FILE_MAP_COPY;
     let protection = if exec {
@@ -331,11 +335,12 @@ impl MmapInner {
 
   pub fn map_copy_read_only(
     len: usize,
-    handle: RawHandle,
+    handle: BorrowedHandle<'_>,
     offset: u64,
     _populate: bool,
     _no_reserve: bool,
   ) -> io::Result<MmapInner> {
+    let handle = handle.as_raw_handle();
     let write = protection_supported(handle, PAGE_READWRITE);
     let exec = protection_supported(handle, PAGE_EXECUTE_READ);
     let mut access = FILE_MAP_COPY;
@@ -397,7 +402,9 @@ impl MmapInner {
           copy: false,
         })
       } else {
-        Err(io::Error::last_os_error())
+        let err = io::Error::last_os_error();
+        UnmapViewOfFile(ptr);
+        Err(err)
       }
     }
   }
@@ -525,11 +532,16 @@ fn allocation_granularity() -> usize {
   }
 }
 
-pub fn file_len(handle: RawHandle) -> io::Result<u64> {
-  // SAFETY: We must not close the passed-in fd by dropping the File we create,
-  // we ensure this by immediately wrapping it in a ManuallyDrop.
+pub fn file_len(handle: BorrowedHandle<'_>) -> io::Result<u64> {
+  // `GetFileSizeEx` only needs a valid, open handle for the call duration —
+  // the `BorrowedHandle` supplied by the caller carries that invariant at
+  // the type level (see `AsHandle`). Unlike `File::from_raw_handle`, we do
+  // not claim ownership and will not close the handle on drop.
   unsafe {
-    let file = ManuallyDrop::new(File::from_raw_handle(handle));
-    Ok(file.metadata()?.len())
+    let mut size: i64 = 0;
+    if GetFileSizeEx(handle.as_raw_handle() as HANDLE, &mut size) == 0 {
+      return Err(io::Error::last_os_error());
+    }
+    Ok(size as u64)
   }
 }


### PR DESCRIPTION
## Summary

Addresses the P1/P2 review findings against 0.8.0 and bumps to **0.9.0**
(breaking: see the trait change below).

- **P1 — Safe range APIs reach unchecked pointer arithmetic.** Added
  a bounds check (`check_range`) to `flush_range`, `flush_async_range`,
  and `advise_range` on `Mmap`, `MmapMut`, and `MmapRaw`. Out-of-bounds
  or overflowing `offset + len` now returns `ErrorKind::InvalidInput`
  before reaching `ptr.offset`/`ptr.add` in the Unix/Windows backends.
- **P1 — `FromRawFd`/`BorrowedFd::borrow_raw` precondition violation
  from safe code.** Refactored to I/O-safety types:
  - `MmapRawDescriptor` now carries `BorrowedFd<'a>` / `BorrowedHandle<'a>`.
  - `MmapAsRawDesc` is gated on `AsFd` / `AsHandle` (replacing `AsRawFd` /
    `AsRawHandle`).
  - `impl MmapAsRawDesc for RawFd` / `RawHandle` **removed**. Callers with
    only a raw integer must now wrap via `unsafe { BorrowedFd::borrow_raw(fd) }`,
    which is where the validity precondition belongs.
  - `os::file_len` and `MmapInner::new`/`map_*` take `BorrowedFd<'_>` /
    `BorrowedHandle<'_>` directly — no `BorrowedFd::borrow_raw` remains on
    any path reachable from a safe API. `file_len` is now a plain safe fn
    using `rustix::fs::fstat` (preserves 64-bit offsets on 32-bit Linux via
    rustix's internal `fstat64` dispatch).
- **P2 — Windows anonymous view leak on `VirtualProtect` failure.**
  `MmapInner::map_anon` now calls `UnmapViewOfFile(ptr)` before returning
  the error.
- **P2 — Release metadata out of sync.** Bumped `Cargo.toml` from `0.8.0` to
  `0.9.0` (minor bump mandated by the breaking trait change above) and added
  a `[0.9.0] - 2026-04-23` changelog entry with a clarifying fork preamble
  noting the memmapix version line is independent of memmap2's.

### Migration for `RawFd`/`RawHandle` callers

```rust
// before
let mmap = unsafe { MmapMut::map_mut(file.as_raw_fd())? };

// after
let fd = file.as_raw_fd();
let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
let mmap = unsafe { MmapMut::map_mut(borrowed)? };
```

`&File` / `File` / `BorrowedFd` / `BorrowedHandle` callers are unaffected.

## Test plan

- [x] `cargo test` — 35 unit + 19 doc tests pass (includes 3 new tests
      covering `check_range` rejection on each of the safe range APIs)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo check --target x86_64-pc-windows-msvc` clean
- [x] `cargo check --target i686-unknown-linux-gnu` clean (exercises the
      32-bit `fstat64` dispatch)
- [x] `cargo fmt --all -- --check` clean
